### PR TITLE
fix: capture SHELLCMD events and persist shell commands to database

### DIFF
--- a/src/snakemake_logger_plugin_snkmt/event_handlers.py
+++ b/src/snakemake_logger_plugin_snkmt/event_handlers.py
@@ -189,7 +189,6 @@ class JobInfoHandler(EventHandler):
         file_type: FileType,
         session: Session,
     ) -> None:
-        """Helper method to add files of a specific type to a job"""
         if not file_paths:
             return
 
@@ -197,6 +196,27 @@ class JobInfoHandler(EventHandler):
             abs_path = Path(path).resolve()
             file = File(path=str(abs_path), file_type=file_type, job_id=job.id)
             session.add(file)
+
+
+class ShellCmdHandler(EventHandler):
+    def handle(
+        self, record: LogRecord, session: Session, context: Dict[str, Any]
+    ) -> None:
+        if "current_workflow_id" not in context or "jobs" not in context:
+            return
+
+        shell_data = parsers.ShellCmd.from_record(record)
+        if not shell_data.shellcmd:
+            return
+
+        snakemake_job_id = getattr(record, "jobid", None)
+        if snakemake_job_id is None or snakemake_job_id not in context["jobs"]:
+            return
+
+        db_job_id = context["jobs"][snakemake_job_id]
+        job = session.query(Job).get(db_job_id)
+        if job:
+            job.shellcmd = shell_data.shellcmd
 
 
 class JobStartedHandler(EventHandler):

--- a/src/snakemake_logger_plugin_snkmt/log_handler.py
+++ b/src/snakemake_logger_plugin_snkmt/log_handler.py
@@ -26,6 +26,7 @@ from snakemake_logger_plugin_snkmt.event_handlers import (
     GroupErrorHandler,
     ErrorHandler,
     RunInfoHandler,
+    ShellCmdHandler,
 )
 
 
@@ -62,6 +63,7 @@ class sqliteLogHandler(Handler):
             LogEvent.GROUP_ERROR.value: GroupErrorHandler(),
             LogEvent.ERROR.value: ErrorHandler(),
             LogEvent.RUN_INFO.value: RunInfoHandler(),
+            LogEvent.SHELLCMD.value: ShellCmdHandler(),
         }
 
         self.context = {


### PR DESCRIPTION
Snakemake emits shell commands as a separate `SHELLCMD` log event after job creation, but no handler existed for it. The `ShellCmd` parser and `LogEvent.SHELLCMD` entry point were already defined but unregistered.

* Added `ShellCmdHandler` in `event_handlers.py` that looks up the job by snakemake job ID from context and updates its `shellcmd` field
* Registered the handler in `log_handler.py` for `LogEvent.SHELLCMD`